### PR TITLE
refactor: resolve clippy lints "all" + "pedantic"

### DIFF
--- a/examples/backbone_app/src/lib.rs
+++ b/examples/backbone_app/src/lib.rs
@@ -133,7 +133,7 @@ pub enum Msg {
 
 fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
-        Msg::UrlChanged(subs::UrlChanged(url)) => {
+        Msg::UrlChanged(subs::UrlChanged(_url)) => {
             router().current_route().init(model, orders);
         }
         Msg::Login(login_message) => pages::login::update(

--- a/router_macro_derive/src/builder.rs
+++ b/router_macro_derive/src/builder.rs
@@ -110,7 +110,7 @@ pub fn inject_variant_payload_in_function_call(
 }
 
 pub fn extract_query_field_to_string() -> TokenStream2 {
-    quote! { convert_to_string(query.clone())}
+    quote! { convert_to_string(&query)}
 }
 pub fn build_string_without_path_name(
     structs_tuple: (Option<&Field>, Option<&Field>, Option<&Field>),

--- a/router_macro_derive/src/lib.rs
+++ b/router_macro_derive/src/lib.rs
@@ -13,7 +13,7 @@ extern crate proc_macro_error;
 use crate::{root::get_default_route, routing::routing_variant_snippets};
 use proc_macro::TokenStream;
 
-use crate::{init::module_init_snippets, modules::modules_path, view::modules_view_snippets};
+use crate::{init::module_init_snippets, view::modules_view_snippets};
 use proc_macro_error::{abort, proc_macro_error, Diagnostic, Level};
 use quote::quote;
 use syn::{export::TokenStream2, parse_macro_input, Data, DeriveInput, Fields};
@@ -364,7 +364,7 @@ pub fn derive_add_module_load(item: TokenStream) -> TokenStream {
     let default_route_impl = TokenStream2::from(root);
     let variants = variants.iter();
 
-    let modules_path = modules_path(ident.clone(), attrs.iter());
+    let modules_path = modules::path(ident.clone(), attrs.iter());
 
     let modules_snippets = modules_view_snippets(variants.clone(), modules_path.clone());
 

--- a/router_macro_derive/src/modules.rs
+++ b/router_macro_derive/src/modules.rs
@@ -3,7 +3,7 @@ use proc_macro_error::{abort, Diagnostic, Level};
 use crate::builder::get_string_from_attribute;
 use syn::{Attribute, Ident};
 
-pub fn modules_path(_: Ident, attrs: std::slice::Iter<'_, Attribute>) -> Option<String> {
+pub fn path(_: Ident, attrs: std::slice::Iter<'_, Attribute>) -> Option<String> {
     let mut attrs =
         attrs.filter_map(
             |attr| match get_string_from_attribute("modules_path", attr) {

--- a/router_macro_derive/src/root.rs
+++ b/router_macro_derive/src/root.rs
@@ -7,7 +7,7 @@ pub fn get_default_route(variants: Iter<'_, Variant>) -> Result<Variant> {
     let mut i = 0;
     let mut default_variant: Option<Variant> = None;
     for v in variants {
-        let default = variant_default_route(v.ident.clone(), v.attrs.iter());
+        let default = variant_default_route(v.ident.clone(), &v.attrs);
         if default {
             i += 1;
             default_variant = Some(v.clone());
@@ -29,12 +29,9 @@ pub fn get_default_route(variants: Iter<'_, Variant>) -> Result<Variant> {
 }
 
 /// Check if default_route exist
-fn variant_default_route(_: Ident, attrs: std::slice::Iter<'_, Attribute>) -> bool {
-    let mut attrs = attrs.filter_map(|attr| Some(attr.path.is_ident("default_route")));
+fn variant_default_route(_: Ident, attrs: &[Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|attr| attr.path.is_ident("default_route"))
 
-    if let Some(exist) = attrs.next() {
-        exist
-    } else {
-        false
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::must_use_candidate)]
 pub mod router;
 
 pub use router::*;

--- a/src/router/path.rs
+++ b/src/router/path.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+#[allow(clippy::module_name_repetitions)]
 pub trait AsPath {
     fn as_path(self) -> String;
 }
@@ -9,7 +10,15 @@ impl<T: ToString> AsPath for T {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub trait ParsePath: AsPath + Sized {
+    /// Implementation is provided for all types implementing `FromStr`, `ToString` and `AsPath`
+    ///
+    /// The provided implementation trims all leading `'/'` characters, before running the std parse
+    ///
+    /// # Errors
+    ///
+    /// Will return Err if it's not possible to parse this string slice into the desired type.
     fn parse_path(route: &str) -> Result<Self, ParseError>;
 }
 #[derive(Debug)]
@@ -21,7 +30,7 @@ pub enum ParseError {
 }
 impl<T: FromStr + ToString + AsPath> ParsePath for T {
     fn parse_path(path: &str) -> Result<Self, ParseError> {
-        path.trim_start_matches("/")
+        path.trim_start_matches('/')
             .parse::<T>()
             .map_err(|_| ParseError::FromStr)
     }


### PR DESCRIPTION
Added warnings for `all` and `pedantic` lints.

Some `module_name_repetitions` warrant a more subjective approach.

`must_use_candidate` can be revisited later.