### PR TITLE
refactor: `Option<Route>` for forward/back functions

### DIFF
--- a/examples/backbone_app/src/lib.rs
+++ b/examples/backbone_app/src/lib.rs
@@ -189,14 +189,14 @@ fn header(model: &Model) -> Node<Msg> {
                 button![
                     "back",
                     attrs! {
-                        At::Disabled  =>   (!  router().can_back()).as_at_value(),
+                        At::Disabled  =>   (!  router().peek_back().is_some()).as_at_value(),
                     },
                     ev(Ev::Click, |_| Msg::GoBack)
                 ],
                 button![
                     "forward",
                     attrs! {
-                        At::Disabled =>  (!  router().can_forward()).as_at_value(),
+                        At::Disabled =>  (!  router().peek_forward().is_some()).as_at_value(),
                     },
                     ev(Ev::Click, |_| Msg::GoForward)
                 ],


### PR DESCRIPTION
Instead of `can_forward() -> bool` and `can_forward_with_route() ->
Option<Route>`, we combine it into `peek_forward() -> Option<Route>`

`forward()` and `back()` also change from `bool` to `Option<Route>` in a
similar manner.

This commit includes a documentation update linking to the corresponding
peek function in the `forward` and `back` function, updated relevant tests,
which also got a few additional asserts to cover more pre and post-conditions.