### PR TITLE
ci: run tests without installing cargo-make

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install cargo-make
-      run: cargo install cargo-make
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: install wasm-pack
+      run: cargo install wasm-pack
     - name: Run wasm tests in web browser
-      run: cargo make test_h firefox
+      run: wasm-pack test --headless --firefox


### PR DESCRIPTION
cargo-make adds overhead to the CI run, and can be replaced by
constructing the commands manually in the ci file.